### PR TITLE
Fix compatibility with AutoCAD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /node_modules
 .vscode/settings.json
+.idea/
+*.iml
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dxf-writer",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/AppId.js
+++ b/src/AppId.js
@@ -1,0 +1,21 @@
+const DatabaseObject = require('./DatabaseObject');
+
+
+class AppId extends DatabaseObject {
+    constructor(name) {
+        super(["AcDbSymbolTableRecord", "AcDbRegAppTableRecord"])
+        this.name = name
+    }
+
+    toDxfString()
+    {
+        let s = "0\nAPPID\n"
+        s += super.toDxfString()
+        s += `2\n${this.name}\n`
+        /* No flags set */
+        s += "70\n0\n"
+        return s
+    }
+}
+
+module.exports = AppId

--- a/src/Arc.js
+++ b/src/Arc.js
@@ -1,4 +1,7 @@
-class Arc
+const DatabaseObject = require('./DatabaseObject')
+
+
+class Arc extends DatabaseObject
 {
     /**
      * @param {number} x1 - Center x
@@ -9,6 +12,7 @@ class Arc
      */
     constructor(x1, y1, r, startAngle, endAngle)
     {
+        super(["AcDbEntity", "AcDbArc"])
         this.x1 = x1;
         this.y1 = y1;
         this.r = r;
@@ -20,6 +24,7 @@ class Arc
     {
         //https://www.autodesk.com/techpubs/autocad/acadr14/dxf/line_al_u05_c.htm
         let s = `0\nARC\n`;
+        s += super.toDxfString()
         s += `8\n${this.layer.name}\n`;
         s += `10\n${this.x1}\n20\n${this.y1}\n30\n0\n`;
         s += `40\n${this.r}\n50\n${this.startAngle}\n51\n${this.endAngle}\n`;

--- a/src/Block.js
+++ b/src/Block.js
@@ -1,0 +1,48 @@
+const DatabaseObject = require('./DatabaseObject')
+
+
+class Block extends DatabaseObject {
+    constructor(name)
+    {
+        super(["AcDbEntity", "AcDbBlockBegin"])
+        this.name = name
+        this.end = new DatabaseObject(["AcDbEntity","AcDbBlockEnd"])
+        this.recordHandle = null
+    }
+
+    /* Internal method to set handle value for block end separator entity. */
+    setEndHandle(handle) {
+        this.end.handle = handle
+    }
+
+    /* Internal method to set handle value for block record in block records table. */
+    setRecordHandle(handle) {
+        this.recordHandle = handle
+    }
+
+    //XXX need some API to add content
+
+    toDxfString()
+    {
+        let s = "0\nBLOCK\n"
+        s += super.toDxfString()
+        s += `2\n${this.name}\n`
+        /* No flags set */
+        s += "70\n0\n"
+        /* Block top left corner */
+        s += "10\n0\n"
+        s += "20\n0\n"
+        s += "30\n0\n"
+        s += `3\n${this.name}\n`
+        /* xref path name - nothing */
+        s += "1\n\n"
+
+        //XXX dump content here
+
+        s += "0\nENDBLK\n"
+        s += this.end.toDxfString()
+        return s
+    }
+}
+
+module.exports = Block

--- a/src/BlockRecord.js
+++ b/src/BlockRecord.js
@@ -1,0 +1,25 @@
+const DatabaseObject = require('./DatabaseObject')
+
+
+class BlockRecord extends DatabaseObject {
+    constructor(name) {
+        super(["AcDbSymbolTableRecord", "AcDbBlockTableRecord"])
+        this.name = name
+    }
+
+    toDxfString()
+    {
+        let s = "0\nBLOCK_RECORD\n"
+        s += super.toDxfString()
+        s += `2\n${this.name}\n`
+        /* No flags set */
+        s += "70\n0\n"
+        /* Block explodability */
+        s += "280\n1\n"
+        /* Block scalability */
+        s += "281\n0\n";
+        return s
+    }
+}
+
+module.exports = BlockRecord

--- a/src/Circle.js
+++ b/src/Circle.js
@@ -1,4 +1,7 @@
-class Circle
+const DatabaseObject = require('./DatabaseObject')
+
+
+class Circle extends DatabaseObject
 {
     /**
      * @param {number} x1 - Center x
@@ -7,6 +10,7 @@ class Circle
      */
     constructor(x1, y1, r)
     {
+        super(["AcDbEntity", "AcDbCircle"])
         this.x1 = x1;
         this.y1 = y1;
         this.r = r;
@@ -16,6 +20,7 @@ class Circle
     {
         //https://www.autodesk.com/techpubs/autocad/acadr14/dxf/circle_al_u05_c.htm
         let s = `0\nCIRCLE\n`;
+        s += super.toDxfString()
         s += `8\n${this.layer.name}\n`;
         s += `10\n${this.x1}\n20\n${this.y1}\n30\n0\n`;
         s += `40\n${this.r}\n`;

--- a/src/DatabaseObject.js
+++ b/src/DatabaseObject.js
@@ -1,0 +1,37 @@
+class DatabaseObject {
+    constructor(subclass = null)
+    {
+        /* Handle should be assigned externally by document instance */
+        this.handle = null
+        this.ownerHandle = null
+        this.subclassMarkers = []
+        if (subclass) {
+            if (Array.isArray(subclass)) {
+                for (const sc of subclass) {
+                    this.subclassMarkers.push(sc)
+                }
+            } else {
+                this.subclassMarkers.push(subclass)
+            }
+        }
+    }
+
+    toDxfString()
+    {
+        let s = ""
+        if (this.handle) {
+            s += `5\n${this.handle.toString(16)}\n`
+        } else {
+            console.warn("No handle assigned to entity", this)
+        }
+        if (this.ownerHandle) {
+            s += `330\n${this.ownerHandle.toString(16)}\n`
+        }
+        for (const marker of this.subclassMarkers) {
+            s += `100\n${marker}\n`
+        }
+        return s
+    }
+}
+
+module.exports = DatabaseObject

--- a/src/Dictionary.js
+++ b/src/Dictionary.js
@@ -1,0 +1,36 @@
+const DatabaseObject = require('./DatabaseObject')
+
+
+class Dictionary extends DatabaseObject {
+    constructor()
+    {
+        super("AcDbDictionary")
+        this.children = {}
+    }
+
+    addChildDictionary(name, dictionary) {
+        if (!this.handle) {
+            throw new Error("Handle must be set before adding children")
+        }
+        dictionary.ownerHandle = this.handle
+        this.children[name] = dictionary
+    }
+
+    toDxfString()
+    {
+        let s = "0\nDICTIONARY\n"
+        s += super.toDxfString()
+        /* Duplicate record cloning flag - keep existing */
+        s += "281\n1\n"
+        for (const [name, item] of Object.entries(this.children)) {
+            s += `3\n${name}\n`
+            s += `350\n${item.handle.toString(16)}\n`
+        }
+        for (const item of Object.values(this.children)) {
+            s += item.toDxfString()
+        }
+        return s
+    }
+}
+
+module.exports = Dictionary

--- a/src/DimStyleTable.js
+++ b/src/DimStyleTable.js
@@ -1,0 +1,27 @@
+const DatabaseObject = require('./DatabaseObject')
+const Table = require('./Table')
+
+
+class DimStyleTable extends Table {
+    constructor(name) {
+        super(name)
+        this.subclassMarkers.push("AcDbDimStyleTable")
+    }
+
+    toDxfString()
+    {
+        let s = "0\nTABLE\n"
+        s += `2\n${this.name}\n`
+        s += DatabaseObject.prototype.toDxfString.call(this)
+        s += `70\n${this.elements.length}\n`
+        /* DIMTOL */
+        s += "71\n1\n"
+        for (const element of this.elements) {
+            s += element.toDxfString()
+        }
+        s += "0\nENDTAB\n"
+        return s
+    }
+}
+
+module.exports = DimStyleTable

--- a/src/Ellipse.js
+++ b/src/Ellipse.js
@@ -1,4 +1,7 @@
-class Ellipse {
+const DatabaseObject = require('./DatabaseObject')
+
+
+class Ellipse extends DatabaseObject {
     /**
      * Creates an ellipse.
      * @param {number} x1 - Center x
@@ -10,6 +13,7 @@ class Ellipse {
      * @param {number} endAngle - End angle
      */
     constructor(x1, y1, majorAxisX, majorAxisY, axisRatio, startAngle, endAngle) {
+        super(["AcDbEntity", "AcDbEllipse"])
         this.x1 = x1;
         this.y1 = y1;
         this.majorAxisX = majorAxisX;
@@ -22,6 +26,7 @@ class Ellipse {
     toDxfString() {
         // https://www.autodesk.com/techpubs/autocad/acadr14/dxf/ellipse_al_u05_c.htm
         let s = `0\nELLIPSE\n`;
+        s += super.toDxfString()
         s += `8\n${this.layer.name}\n`;
         s += `10\n${this.x1}\n`;
         s += `20\n${this.y1}\n`;

--- a/src/Face.js
+++ b/src/Face.js
@@ -1,7 +1,11 @@
-class Face
+const DatabaseObject = require('./DatabaseObject')
+
+
+class Face extends DatabaseObject
 {
     constructor(x1, y1, z1, x2, y2, z2, x3, y3, z3, x4, y4, z4)
     {
+        super(["AcDbEntity", "AcDbFace"])
         this.x1 = x1;
         this.y1 = y1;
         this.z1 = z1;
@@ -20,6 +24,7 @@ class Face
     {
         //https://www.autodesk.com/techpubs/autocad/acadr14/dxf/3dface_al_u05_c.htm
         let s = `0\n3DFACE\n`;
+        s += super.toDxfString()
         s += `8\n${this.layer.name}\n`;
         s += `10\n${this.x1}\n20\n${this.y1}\n30\n${this.z1}\n`;
         s += `11\n${this.x2}\n21\n${this.y2}\n31\n${this.z2}\n`;

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -1,7 +1,11 @@
-class Layer
+const DatabaseObject = require('./DatabaseObject')
+
+
+class Layer extends DatabaseObject
 {
-    constructor(name, colorNumber, lineTypeName)
+    constructor(name, colorNumber, lineTypeName = null)
     {
+        super(["AcDbSymbolTableRecord", "AcDbLayerTableRecord"])
         this.name = name;
         this.colorNumber = colorNumber;
         this.lineTypeName = lineTypeName;
@@ -12,7 +16,7 @@ class Layer
     toDxfString()
     {
         let s = '0\nLAYER\n';
-        s += '70\n64\n';
+        s += super.toDxfString();
         s += `2\n${this.name}\n`;
         if (this.trueColor !== -1)
         {
@@ -22,8 +26,15 @@ class Layer
         {
             s += `62\n${this.colorNumber}\n`;
         }
-        s += `6\n${this.lineTypeName}\n`;
-        return s;        
+        s += '70\n0\n';
+        if (this.lineTypeName) {
+            s += `6\n${this.lineTypeName}\n`;
+        }
+        /* Hard-pointer handle to PlotStyleName object; seems mandatory, but any value seems OK,
+         * including 0.
+         */
+        s += "390\n1\n";
+        return s;
     }
 
     setTrueColor(color)

--- a/src/Line.js
+++ b/src/Line.js
@@ -1,7 +1,11 @@
-class Line
+const DatabaseObject = require('./DatabaseObject')
+
+
+class Line extends DatabaseObject
 {
     constructor(x1, y1, x2, y2)
     {
+        super(["AcDbEntity", "AcDbLine"])
         this.x1 = x1;
         this.y1 = y1;
         this.x2 = x2;
@@ -12,6 +16,7 @@ class Line
     {
         //https://www.autodesk.com/techpubs/autocad/acadr14/dxf/line_al_u05_c.htm
         let s = `0\nLINE\n`;
+        s += super.toDxfString()
         s += `8\n${this.layer.name}\n`;
         s += `10\n${this.x1}\n20\n${this.y1}\n30\n0\n`;
         s += `11\n${this.x2}\n21\n${this.y2}\n31\n0\n`;

--- a/src/LineType.js
+++ b/src/LineType.js
@@ -1,4 +1,7 @@
-class LineType
+const DatabaseObject = require('./DatabaseObject')
+
+
+class LineType extends DatabaseObject
 {
     /**
      * @param {string} name
@@ -7,6 +10,7 @@ class LineType
      */
     constructor(name, description, elements)
     {
+        super(["AcDbSymbolTableRecord", "AcDbLinetypeTableRecord"])
         this.name = name;
         this.description = description;
         this.elements = elements;
@@ -18,16 +22,18 @@ class LineType
     toDxfString()
     {
         let s = '0\nLTYPE\n';
-        s += '72\n65\n';
-        s += '70\n64\n';
+        s += super.toDxfString()
         s += `2\n${this.name}\n`;
         s += `3\n${this.description}\n`;
+        s += '70\n0\n';
+        s += '72\n65\n';
         s += `73\n${this.elements.length}\n`;
         s += `40\n${this.getElementsSum()}\n`;
-
-        for (let i = 0; i < this.elements.length; ++i)
+        for (const element of this.elements)
         {
-            s += `49\n${this.elements[i]}\n`;
+            s += `49\n${element}\n`;
+            /* Complex linetype element type, mandatory for AutoCAD */
+            s += '74\n0\n';
         }
 
         return s;

--- a/src/Point.js
+++ b/src/Point.js
@@ -1,7 +1,11 @@
-class Point
+const DatabaseObject = require('./DatabaseObject')
+
+
+class Point extends DatabaseObject
 {
     constructor(x, y)
     {
+        super(["AcDbEntity", "AcDbEntity"])
         this.x = x;
         this.y = y;
     }
@@ -10,6 +14,7 @@ class Point
     {
         //https://www.autodesk.com/techpubs/autocad/acadr14/dxf/point_al_u05_c.htm
         let s = `0\nPOINT\n`;
+        s += super.toDxfString()
         s += `8\n${this.layer.name}\n`;
         s += `10\n${this.x}\n20\n${this.y}\n30\n0\n`;
         return s;

--- a/src/Polyline.js
+++ b/src/Polyline.js
@@ -1,4 +1,7 @@
-class Polyline
+const DatabaseObject = require('./DatabaseObject')
+
+
+class Polyline extends DatabaseObject
 {
     /**
      * @param {array} points - Array of points like [ [x1, y1], [x2, y2, bulge]... ]
@@ -8,6 +11,7 @@ class Polyline
      */
     constructor(points, closed = false, startWidth = 0, endWidth = 0)
     {
+        super(["AcDbEntity", "AcDbPolyline"])
         this.points = points;
         this.closed = closed;
         this.startWidth = startWidth;
@@ -16,27 +20,25 @@ class Polyline
 
     toDxfString()
     {
-        //https://www.autodesk.com/techpubs/autocad/acad2000/dxf/polyline_dxf_06.htm
-        //https://www.autodesk.com/techpubs/autocad/acad2000/dxf/vertex_dxf_06.htm
-        let s = `0\nPOLYLINE\n`;
+        let s = `0\nLWPOLYLINE\n`;
+        s += super.toDxfString()
         s += `8\n${this.layer.name}\n`;
-        s += `66\n1\n70\n${this.closed ? 1 : 0}\n`;
-        if (this.startWidth !== 0 || this.endWidth !== 0) {
-            s += `40\n${this.startWidth}\n41\n${this.endWidth}\n`;
-        }
+        s += "6\nByLayer\n"
+        s += "62\n256\n"
+        s += "370\n-1\n"
+        s += `70\n${this.closed ? 1 : 0}\n`;
+        s += `90\n${this.points.length}\n`
 
-        for (let i = 0; i < this.points.length; ++i)
-        {
-            s += `0\nVERTEX\n`;
-            s += `8\n${this.layer.name}\n`;
-            s += `70\n0\n`;
-            s += `10\n${this.points[i][0]}\n20\n${this.points[i][1]}\n`;
-            if (this.points[i][2] !== undefined) {
-                s += `42\n${this.points[i][2]}\n`;
+        for (const p of this.points) {
+            s += `10\n${p[0]}\n20\n${p[1]}\n`;
+            if (this.startWidth !== 0 || this.endWidth !== 0) {
+                s += `40\n${this.startWidth}\n41\n${this.endWidth}\n`;
+            }
+            if (p[2] !== undefined) {
+                s += `42\n${p[2]}\n`;
             }
         }
-        
-        s += `0\nSEQEND\n`;
+
         return s;
     }
 }

--- a/src/Polyline3d.js
+++ b/src/Polyline3d.js
@@ -1,11 +1,20 @@
-class Polyline3d
+const DatabaseObject = require('./DatabaseObject')
+
+
+class Polyline3d extends DatabaseObject
 {
     /**
      * @param {array} points - Array of points like [ [x1, y1, z1], [x2, y2, z2]... ]
      */
     constructor(points)
     {
+        super(["AcDbEntity", "AcDbPolyline3D"])
         this.points = points;
+        this.pointHandles = null;
+    }
+
+    assignVertexHandles(handleProvider) {
+        this.pointHandles = this.points.map(() => handleProvider())
     }
 
     toDxfString()
@@ -13,12 +22,16 @@ class Polyline3d
         //https://www.autodesk.com/techpubs/autocad/acad2000/dxf/polyline_dxf_06.htm
         //https://www.autodesk.com/techpubs/autocad/acad2000/dxf/vertex_dxf_06.htm
         let s = `0\nPOLYLINE\n`;
+        s += super.toDxfString()
         s += `8\n${this.layer.name}\n`;
         s += `66\n1\n70\n8\n`;
 
         for (let i = 0; i < this.points.length; ++i)
         {
             s += `0\nVERTEX\n`;
+            s += "100\nAcDbEntity\n";
+            s += "100\nAcDbVertex\n";
+            s += `5\n${this.pointHandles[i].toString(16)}\n`;
             s += `8\n${this.layer.name}\n`;
             s += `70\n0\n`;
             s += `10\n${this.points[i][0]}\n20\n${this.points[i][1]}\n30\n${this.points[i][2]}\n`;

--- a/src/Spline.js
+++ b/src/Spline.js
@@ -1,4 +1,7 @@
-class Spline
+const DatabaseObject = require('./DatabaseObject')
+
+
+class Spline extends DatabaseObject
 {
     /**
      * Creates a spline. See https://www.autodesk.com/techpubs/autocad/acad2000/dxf/spline_dxf_06.htm
@@ -10,6 +13,7 @@ class Spline
      */
     constructor(controlPoints, degree = 3, knots = null, weights = null, fitPoints = [])
     {
+        super(["AcDbEntity", "AcDbSpline"])
         if (controlPoints.length < degree + 1) {
             throw new Error(`For degree ${degree} spline, expected at least ${degree + 1} control points, but received only ${controlPoints.length}`);
         }
@@ -70,8 +74,8 @@ class Spline
     toDxfString() {
         // https://www.autodesk.com/techpubs/autocad/acad2000/dxf/spline_dxf_06.htm
         let s = `0\nSPLINE\n`;
+        s += super.toDxfString()
         s += `8\n${this.layer.name}\n`;
-        s += `100\nAcDbSpline\n`;
         s += `210\n0.0\n220\n0.0\n230\n1.0\n`;
 
         s += `70\n${this.type}\n`;

--- a/src/Table.js
+++ b/src/Table.js
@@ -1,0 +1,29 @@
+const DatabaseObject = require('./DatabaseObject')
+
+
+class Table extends DatabaseObject {
+    constructor(name) {
+        super("AcDbSymbolTable")
+        this.name = name
+        this.elements = []
+    }
+
+    add(element) {
+        this.elements.push(element)
+    }
+
+    toDxfString()
+    {
+        let s = "0\nTABLE\n"
+        s += `2\n${this.name}\n`
+        s += super.toDxfString()
+        s += `70\n${this.elements.length}\n`
+        for (const element of this.elements) {
+            s += element.toDxfString()
+        }
+        s += "0\nENDTAB\n"
+        return s
+    }
+}
+
+module.exports = Table

--- a/src/Text.js
+++ b/src/Text.js
@@ -1,7 +1,10 @@
+const DatabaseObject = require('./DatabaseObject')
+
+
 const H_ALIGN_CODES = ['left', 'center', 'right'];
 const V_ALIGN_CODES = ['baseline','bottom', 'middle', 'top'];
 
-class Text
+class Text extends DatabaseObject
 {
     /**
      * @param {number} x1 - x
@@ -14,6 +17,7 @@ class Text
      */
     constructor(x1, y1, height, rotation, value, horizontalAlignment = 'left', verticalAlignment = 'baseline')
     {
+        super(["AcDbEntity", "AcDbText"])
         this.x1 = x1;
         this.y1 = y1;
         this.height = height;
@@ -27,14 +31,21 @@ class Text
     {
         //https://www.autodesk.com/techpubs/autocad/acadr14/dxf/text_al_u05_c.htm
         let s = `0\nTEXT\n`;
+        s += super.toDxfString()
         s += `8\n${this.layer.name}\n`;
-        s += `1\n${this.value}\n`;
         s += `10\n${this.x1}\n20\n${this.y1}\n30\n0\n`;
-        s += `40\n${this.height}\n50\n${this.rotation}\n`;
-        if (H_ALIGN_CODES.includes(this.hAlign, 1) || V_ALIGN_CODES.includes(this.vAlign, 1)){
+        s += `40\n${this.height}\n`;
+        s += `1\n${this.value}\n`;
+        s += `50\n${this.rotation}\n`;
+        if (H_ALIGN_CODES.includes(this.hAlign, 1) || V_ALIGN_CODES.includes(this.vAlign, 1)) {
+            s += `72\n${Math.max(H_ALIGN_CODES.indexOf(this.hAlign), 0)}\n`;
             s += `11\n${this.x1}\n21\n${this.y1}\n31\n0\n`;
-            s += `72\n${Math.max(H_ALIGN_CODES.indexOf(this.hAlign),0)}\n`;
-            s += `73\n${Math.max(V_ALIGN_CODES.indexOf(this.vAlign),0)}\n`;
+            /* AutoCAD needs this one more time, yes, exactly here. */
+            s += "100\nAcDbText\n";
+            s += `73\n${Math.max(V_ALIGN_CODES.indexOf(this.vAlign), 0)}\n`;
+        } else {
+            /* AutoCAD needs this one more time. */
+            s += "100\nAcDbText\n";
         }
         return s;
     }

--- a/src/TextStyle.js
+++ b/src/TextStyle.js
@@ -1,0 +1,28 @@
+const DatabaseObject = require('./DatabaseObject')
+
+
+class TextStyle extends DatabaseObject {
+    constructor(name) {
+        super(["AcDbSymbolTableRecord", "AcDbTextStyleTableRecord"])
+        this.name = name
+    }
+
+    toDxfString()
+    {
+        let s = "0\nSTYLE\n"
+        s += super.toDxfString()
+        s += `2\n${this.name}\n`
+        /* No flags set */
+        s += "70\n0\n"
+        s += "40\n0\n"
+        s += "41\n1\n"
+        s += "50\n0\n"
+        s += "71\n0\n"
+        s += "42\n1\n"
+        s += `3\n${this.name}\n`
+        s += "4\n\n"
+        return s
+    }
+}
+
+module.exports = TextStyle

--- a/src/Viewport.js
+++ b/src/Viewport.js
@@ -1,0 +1,24 @@
+const DatabaseObject = require('./DatabaseObject')
+
+
+class Viewport extends DatabaseObject {
+    constructor(name, height)
+    {
+        super(["AcDbSymbolTableRecord", "AcDbViewportTableRecord"])
+        this.name = name
+        this.height = height
+    }
+
+    toDxfString()
+    {
+        let s = "0\nVPORT\n"
+        s += super.toDxfString()
+        s += `2\n${this.name}\n`
+        s += `40\n${this.height}\n`
+        /* No flags set */
+        s += "70\n0\n"
+        return s
+    }
+}
+
+module.exports = Viewport


### PR DESCRIPTION
Resolves #46.
Introduce handles for each DXF file entity.
Add all required entities.
Fix group order for some entities.
Add subclass markers for all entities.
We adopted this patch in our fork and it produces a file which can be opened by Autodesk online viewer (will check later with AutoCAD and Civil3D). However, currently we use only line, polyline and text entities, probably other entities still may have compatibility issues. This also probably fixes issue #22 for the mentioned entities.