### PR TITLE
Update TagsManager.js

### DIFF
--- a/src/TagsManager.js
+++ b/src/TagsManager.js
@@ -74,7 +74,7 @@ class TagsManager {
      */
     toDxfString() {
         return this._tags.reduce((dxfString, tag) => {
-            return `${dxfString}${tag.dxfString()}`;
+            return `${dxfString}${tag.toDxfString()}`;
         }, "");
     }
 }


### PR DESCRIPTION
Hi, 
First of all, thank you for your work! I found an error, the function "toDxfString" in "TagsManager.js" use the same function of "Tag", but is incorrectly referenced,
This is the correct function:

return `${dxfString}${tag.toDxfString()}`;

Best regards