### PR TITLE
3d point support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,7 +48,6 @@ declare module "dxf-writer" {
         push(code: string | number, value: string | number): void;
     }
 
-
     export class Arc extends RenderableToDxf {
         public x1: number;
         public y1: number;
@@ -279,7 +278,7 @@ declare module "dxf-writer" {
         ): Drawing;
         setActiveLayer(name: string): Drawing;
         drawLine(x1: number, y1: number, x2: number, y2: number): Drawing;
-        drawPoint(x: number, y: number): Drawing;
+        drawPoint(x: number, y: number, z?: number): Drawing;
 
         /**
          * draws a closed rectangular polyline with option for round or diagonal corners

--- a/src/Drawing.js
+++ b/src/Drawing.js
@@ -97,8 +97,8 @@ class Drawing {
         return this;
     }
 
-    drawPoint(x, y) {
-        this.activeLayer.addShape(new Point(x, y));
+    drawPoint(x, y, z = 0) {
+        this.activeLayer.addShape(new Point(x, y, z));
         return this;
     }
 

--- a/src/Point.js
+++ b/src/Point.js
@@ -1,10 +1,11 @@
 const DatabaseObject = require("./DatabaseObject");
 
 class Point extends DatabaseObject {
-    constructor(x, y) {
+    constructor(x, y, z) {
         super(["AcDbEntity", "AcDbPoint"]);
         this.x = x;
         this.y = y;
+        this.z = z;
     }
 
     tags(manager) {
@@ -12,7 +13,7 @@ class Point extends DatabaseObject {
         manager.push(0, "POINT");
         super.tags(manager);
         manager.push(8, this.layer.name);
-        manager.point(this.x, this.y);
+        manager.point(this.x, this.y, this.z);
     }
 }
 


### PR DESCRIPTION
This upgrades `drawPoint()` to support both 3D and 2D points.  Note that for the pre-existing 2D case,  `manager.point()` is already writing a 3D point with z=0.